### PR TITLE
Add recursive option for coverage test

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   },
   "scripts": {
     "test": "npm run lint && npm run test-cov",
-    "test-cov": "./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha -- --recursive --check-leaks",
-    "test-coveralls": "./node_modules/.bin/istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec --recursive --check-leaks && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage",
+    "test-cov": "./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha --report lcovonly -- -R spec --recursive --check-leaks",
+    "test-coveralls": "npm run test-cov && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage",
     "lint": "./node_modules/.bin/eslint . --quiet",
     "benchmark": "node ./tools/benchmark"
   },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "test": "npm run lint && npm run test-cov",
     "test-cov": "./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha -- --recursive --check-leaks",
-    "test-coveralls": "./node_modules/.bin/istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage",
+    "test-coveralls": "./node_modules/.bin/istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec --recursive --check-leaks && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage",
     "lint": "./node_modules/.bin/eslint . --quiet",
     "benchmark": "node ./tools/benchmark"
   },


### PR DESCRIPTION
Fix #17 

It seems that I forgot about `--recursive` option for coverage tests.